### PR TITLE
update relatedLots field descriptions to neutral voice

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Report issues for this extension in the [ocds-extensions repository](https://git
 ### Unreleased
 
 * Add `Lot.minValue` field
-* Update field descriptions to neutral voice
+* Update field descriptions to use a neutral voice
 
 ### v1.1.5
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Report issues for this extension in the [ocds-extensions repository](https://git
 ### Unreleased
 
 * Add `Lot.minValue` field
+* Update field descriptions to neutral voice
 
 ### v1.1.5
 

--- a/release-schema.json
+++ b/release-schema.json
@@ -12,7 +12,7 @@
         },
         "lotDetails": {
           "title": "Lot Details",
-          "description": "If this tender is divided into lots, details can be provided here of any criteria that apply to bidding on these lots.",
+          "description": "Details of any criteria that apply to bidding on the lots in the tender",
           "type": "object",
           "properties": {
             "maximumLotsBidPerSupplier": {

--- a/release-schema.json
+++ b/release-schema.json
@@ -55,7 +55,7 @@
       "properties": {
         "relatedLots": {
           "title": "Related lot(s)",
-          "description": "If this document relates to a particular lot, provide the identifier(s) of the related lot(s) here.",
+          "description": "The identifiers of the lots to which this document relates.",
           "type": [
             "array",
             "null"
@@ -71,8 +71,8 @@
     "Item": {
       "properties": {
         "relatedLot": {
-          "title": "Related lot",
-          "description": "If this item belongs to a lot, provide the identifier of the related lot here.",
+          "title": "Related lot(s)",
+          "description": "The identifier of the lot to which this item relates.",
           "type": [
             "string",
             "null"
@@ -84,7 +84,7 @@
       "properties": {
         "relatedLots": {
           "title": "Related lot(s)",
-          "description": "If this milestone relates to a particular lot, provide the identifier(s) of the related lot(s) here.",
+          "description": "The identifiers of the lots to which this milestone relates.",
           "type": [
             "array",
             "null"
@@ -101,7 +101,7 @@
       "properties": {
         "relatedLots": {
           "title": "Related lot(s)",
-          "description": "If this award relates to one or more specific lots, provide the identifier(s) of the related lot(s) here.",
+          "description": "The identifiers of the lots to which this award relates.",
           "type": [
             "array",
             "null"
@@ -118,7 +118,7 @@
       "properties": {
         "relatedLots": {
           "title": "Related lot(s)",
-          "description": "If this bid relates to one or more specific lots, provide the identifier(s) of the related lot(s) here.",
+          "description": "The identifiers of the lots to which this bid relates.",
           "type": [
             "array",
             "null"
@@ -135,7 +135,7 @@
       "properties": {
         "relatedLots": {
           "title": "Related lot(s)",
-          "description": "If this source of finance relates to one or more specific lots, provide the identifier(s) of the related lot(s) here.",
+          "description": "The identifiers of the lots to which this source of finance relates.",
           "type": [
             "array",
             "null"

--- a/release-schema.json
+++ b/release-schema.json
@@ -71,7 +71,7 @@
     "Item": {
       "properties": {
         "relatedLot": {
-          "title": "Related lot(s)",
+          "title": "Related lot",
           "description": "The identifier of the lot to which this item relates.",
           "type": [
             "string",

--- a/release-schema.json
+++ b/release-schema.json
@@ -12,7 +12,7 @@
         },
         "lotDetails": {
           "title": "Lot Details",
-          "description": "Details of any criteria that apply to bidding on the lots in the tender",
+          "description": "Details of any criteria that apply to bidding on the lots in this tender.",
           "type": "object",
           "properties": {
             "maximumLotsBidPerSupplier": {


### PR DESCRIPTION
fixes https://github.com/open-contracting/ocds-extensions/issues/181

I haven't changed the description for `Tender.LotDetails` as I actually don't think it does need it. I've also not changed `Item.relatedLot` to `Item.relatedLots` as I realised unlike the others it's not an array and can only be a singular Lot.