### PR TITLE
make Lot.id and LotGroup.id required, branched from master

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Report issues for this extension in the [ocds-extensions repository](https://git
 ### Unreleased
 
 * Add `Lot.minValue` field
+* Make `Lot.id` and `LotGroup.id` required so that Lots and LotGroups are merged by identifier
 
 ### v1.1.5
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Report issues for this extension in the [ocds-extensions repository](https://git
 ### Unreleased
 
 * Add `Lot.minValue` field
-* Make `Lot.id` and `LotGroup.id` required so that Lots and LotGroups are merged by identifier
+* Make `Lot.id` and `LotGroup.id` required so that lots and lot groups are merged by identifier
 
 ### v1.1.5
 

--- a/release-schema.json
+++ b/release-schema.json
@@ -152,6 +152,9 @@
       "title": "Lots",
       "description": "A lot is a grouping of items within a tender that can be bid on or awarded together.",
       "type": "object",
+      "required": [
+        "id"
+      ],
       "properties": {
         "id": {
           "title": "Lot ID",
@@ -215,6 +218,9 @@
       "title": "Lot group",
       "description": "Where the buyer reserves the right to combine lots, or wishes to specify the total value for a group of lots, a lot group is used to capture this information.",
       "type": "object",
+      "required": [
+        "id"
+      ],
       "properties": {
         "id": {
           "title": "Lot group identifier",


### PR DESCRIPTION
fixes https://github.com/open-contracting-extensions/ocds_lots_extension/pull/36 and partially addresses the issue in https://github.com/open-contracting/standard/issues/650