### PR TITLE
Usage guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # Lots
 
-When a single tender is broken down into parts that can be bid upon, and awarded, separately, this is modelled using the **lots extension**.
+A lot is a grouping of items within a contracting process that can be bid on or awarded together. This extension adds the concept of a lot to OCDS.
+
+## Usage
+
+If a contracting process is divided into lots, you should use this extension.
+
+If a contracting process is not divided into lots, you should nonetheless use this extension to create a single, virtual lot. When a data element can be mapped to either `tender` or `tender.lots`, you should map it to `tender.lots`. In this way, information is accessible at the same location for all contracting processes, regardless of whether the process is actually divided into lots.
+
+## Modelling
 
 The lots extension maintains the overall structure of an OCDS release, with items, documents and milestones nested immediately within `tender`, `awards` and `contracts` sections, but it introduces an array of Lots in the `tender` section, and the ability to cross-reference a specific `relatedLot` for each item, and an array of `relatedLots` for documents, milestones and awards.
 
@@ -182,6 +190,7 @@ Report issues for this extension in the [ocds-extensions repository](https://git
 * Move `Bid.relatedLots` to the Bid statistics and details extension
 * Move `Finance.relatedLots` to the Finance extension
 * Update field descriptions to use a neutral voice
+* Add usage guidance to `README.md`
 
 ### v1.1.5
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ A lot is a grouping of items within a contracting process that can be bid on or 
 
 ## Usage
 
-If a contracting process is divided into lots, you should use this extension.
+If a contracting process is divided into lots, then you should add each lot to the `tender.lots` array.
 
-If a contracting process is not divided into lots, you should nonetheless use this extension to create a single, virtual lot. If a data element can be mapped to either `tender` or `tender.lots`, you should map it to `tender.lots`. In this way, information is accessible at the same location for all contracting processes, regardless of whether the process is actually divided into lots.
+If a contracting process is not divided into lots, then you should nonetheless add a single, virtual lot. If a data element can be mapped to either a `tender` field or a `tender.lots` field, you should map it to the `tender.lots` field. In this way, information is accessible at the same location for all contracting processes, regardless of whether the process is actually divided into lots.
 
 ## Modelling
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A lot is a grouping of items within a contracting process that can be bid on or 
 
 If a contracting process is divided into lots, you should use this extension.
 
-If a contracting process is not divided into lots, you should nonetheless use this extension to create a single, virtual lot. When a data element can be mapped to either `tender` or `tender.lots`, you should map it to `tender.lots`. In this way, information is accessible at the same location for all contracting processes, regardless of whether the process is actually divided into lots.
+If a contracting process is not divided into lots, you should nonetheless use this extension to create a single, virtual lot. If a data element can be mapped to either `tender` or `tender.lots`, you should map it to `tender.lots`. In this way, information is accessible at the same location for all contracting processes, regardless of whether the process is actually divided into lots.
 
 ## Modelling
 
@@ -190,7 +190,7 @@ Report issues for this extension in the [ocds-extensions repository](https://git
 * Move `Bid.relatedLots` to the Bid statistics and details extension
 * Move `Finance.relatedLots` to the Finance extension
 * Update field descriptions to use a neutral voice
-* Add usage guidance to `README.md`
+* Add usage guidance
 
 ### v1.1.5
 


### PR DESCRIPTION
From https://github.com/open-contracting-extensions/ocds_bidOpening_extension/pull/2#issuecomment-1438766895

I'm unsure if we should remove or update the following sentence from `README.md`:

> This means that systems which are not 'lot aware' can still understand the overall value of contracting taking place, key events, and relationships between buyers and suppliers. At the same time, 'lot aware' systems can make use of the cross-referenced information to present a lot-centric view on the information to users, or to analyze contracting lot by lot.

If we keep it, we should perhaps add further guidance to the usage section to explain how to populate at least `tender.value` (sum the values of each lot).

