### PR TITLE
update definition of RelatedProcess.relatedLots

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ An array of `relatedLots` (plural) can be provided for each of:
 * documents
 * milestones
 * awards
+* relatedProcesses
 
 In other extensions, the following objects can also declare related lots:
 

--- a/release-schema.json
+++ b/release-schema.json
@@ -130,7 +130,7 @@
       "properties": {
         "relatedLots": {
           "title": "Related lot(s)",
-          "description": "The identifiers of the lots to which this related process relates.",
+          "description": "The identifiers of the lots in the related process to which this process relates.",
           "type": [
             "array",
             "null"


### PR DESCRIPTION
As discussed in https://github.com/open-contracting/ocds-extensions/issues/29#issuecomment-1847047430 the definition of `RelatedProcess.relatedLots` was incorrect. This PR does not close the issue though as there's still some documentation updates to be done but doing this PR ahead of this as some publishers are already starting to implement this field.