### PR TITLE
add lots.submissionTerms.electronicSubmissionPolicy

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Although part of the same tender, the buyer is willing to award these different 
         },
         "submissionMethodDetails": "https://www.acme.com/tender-submission/. All missing tenderer-related documents can be submitted later. Economic operators who ...",
         "submissionTerms": {
-          "electronicSubmissionPolicy": "required",
+          "electronicSubmissionPolicy": "required"
         },
         "enquiryPeriod": {
           "endDate": "2020-07-15T23:59:59+01:00"
@@ -182,7 +182,7 @@ Although part of the same tender, the buyer is willing to award these different 
         },
         "submissionMethodDetails": "https://www.acme.com/tender-submission/. All missing tenderer-related documents can be submitted later. Economic operators who ...",
         "submissionTerms": {
-          "electronicSubmissionPolicy": "required",
+          "electronicSubmissionPolicy": "required"
         },
         "enquiryPeriod": {
           "endDate": "2020-07-15T23:59:59+01:00"
@@ -226,7 +226,7 @@ Although part of the same tender, the buyer is willing to award these different 
         },
         "submissionMethodDetails": "https://www.acme.com/tender-submission/. All missing tenderer-related documents can be submitted later. Economic operators who ...",
         "submissionTerms": {
-          "electronicSubmissionPolicy": "required",
+          "electronicSubmissionPolicy": "required"
         },
         "enquiryPeriod": {
           "endDate": "2020-07-15T23:59:59+01:00"

--- a/README.md
+++ b/README.md
@@ -315,11 +315,11 @@ Report issues for this extension in the [ocds-extensions repository](https://git
   * `Lot.milestones`
   * `Lot.minValue`
   * `Lot.submissionMethodDetails`
+  * `Lot.submissionTerms`
   * `LotGroup.identifiers`
   * `LotGroup.title`
   * `LotGroup.description`
   * `RelatedProcess.relatedLots`
-  * `Lot.submissionTerms`
 * Make `Lot.id` and `LotGroup.id` required so that lots and lot groups are merged by identifier
 * Move `Bid.relatedLots` to the Bid statistics and details extension
 * Move `Finance.relatedLots` to the Finance extension

--- a/README.md
+++ b/README.md
@@ -129,6 +129,9 @@ Although part of the same tender, the buyer is willing to award these different 
           "endDate": "2020-07-30T23:59:59+01:00"
         },
         "submissionMethodDetails": "https://www.acme.com/tender-submission/. All missing tenderer-related documents can be submitted later. Economic operators who ...",
+        "submissionTerms": {
+          "electronicSubmissionPolicy": "required",
+        },
         "enquiryPeriod": {
           "endDate": "2020-07-15T23:59:59+01:00"
         },
@@ -178,6 +181,9 @@ Although part of the same tender, the buyer is willing to award these different 
           "endDate": "2020-07-30T23:59:59+01:00"
         },
         "submissionMethodDetails": "https://www.acme.com/tender-submission/. All missing tenderer-related documents can be submitted later. Economic operators who ...",
+        "submissionTerms": {
+          "electronicSubmissionPolicy": "required",
+        },
         "enquiryPeriod": {
           "endDate": "2020-07-15T23:59:59+01:00"
         },
@@ -219,6 +225,9 @@ Although part of the same tender, the buyer is willing to award these different 
           "endDate": "2020-07-30T23:59:59+01:00"
         },
         "submissionMethodDetails": "https://www.acme.com/tender-submission/. All missing tenderer-related documents can be submitted later. Economic operators who ...",
+        "submissionTerms": {
+          "electronicSubmissionPolicy": "required",
+        },
         "enquiryPeriod": {
           "endDate": "2020-07-15T23:59:59+01:00"
         },
@@ -310,6 +319,7 @@ Report issues for this extension in the [ocds-extensions repository](https://git
   * `LotGroup.title`
   * `LotGroup.description`
   * `RelatedProcess.relatedLots`
+  * `Lot.submissionTerms`
 * Make `Lot.id` and `LotGroup.id` required so that lots and lot groups are merged by identifier
 * Move `Bid.relatedLots` to the Bid statistics and details extension
 * Move `Finance.relatedLots` to the Finance extension

--- a/release-schema.json
+++ b/release-schema.json
@@ -299,7 +299,7 @@
         "submissionTerms": {
           "title": "Submission terms",
           "description": "Information about how, when and where tenderers need to submit their bids.",
-          "$ref": "#/definitions/submissionTerms"
+          "$ref": "#/definitions/SubmissionTerms"
         }
       }
     },

--- a/release-schema.json
+++ b/release-schema.json
@@ -295,6 +295,11 @@
             "null"
           ],
           "minLength": 1
+        },
+        "submissionTerms": {
+          "title": "Submission terms",
+          "description": "Information about how, when and where tenderers need to submit their bids.",
+          "$ref": "#/definitions/submissionTerms"
         }
       }
     },


### PR DESCRIPTION
The test is failing I think because it's looking in core 1.1 for the field referenced by `#/definitions/submissionTerms` which has been added to 1.2-dev in https://github.com/open-contracting/standard/pull/1654